### PR TITLE
This PR brings a significant set of enhancements to the Cities Overlay script covering visual customisation, geometry engine improvements, UI polish, power-button restoration, and code quality. All changes are confined to `WMECitiesOverlay.js`.

### DIFF
--- a/WMECitiesOverlay.js
+++ b/WMECitiesOverlay.js
@@ -1,13 +1,14 @@
 // ==UserScript==
 // @name         WME Cities Overlay
 // @namespace    https://greasyfork.org/en/users/166843-wazedev
-// @version      2025.08.18.00
+// @version      2026.03.08.00
 // @description  Adds a city overlay for selected states
 // @author       WazeDev
 // @match        https://www.waze.com/*/editor*
 // @match        https://www.waze.com/editor*
 // @match        https://beta.waze.com/*
 // @exclude      https://www.waze.com/*user/*editor/*
+// @require      https://cdn.jsdelivr.net/npm/@turf/turf@7/turf.min.js
 // @require      https://greasyfork.org/scripts/24851-wazewrap/code/WazeWrap.js
 // @require      https://update.greasyfork.org/scripts/546306/1644332/WME%20Cities%20Overlay_DB.js
 // @require      https://update.greasyfork.org/scripts/524747/1542062/GeoKMLer.js
@@ -21,6 +22,7 @@
 /* ecmaVersion 2017 */
 /* global $ */
 /* global idbKeyval */
+/* global turf */
 /* global WazeWrap */
 /* global I18n */
 /* eslint curly: ["warn", "multi-or-nest"] */
@@ -38,15 +40,26 @@
   let _kml; // Holds the raw input KML File data
   let _layer = null; // Holds the geoJSON converted features to map with the SDK
   const layerid = scriptName.replace(/[^a-z0-9_-]/gi, '_');
+  const labelsLayerId = `${layerid}_labels`;
 
-  //Default settings
-  const _color = '#E6E6E6';
-  const defaultFillOpacity = 0.3;
-  const defaultStrokeOpacity = 0.6;
-  const noFillStrokeOpacity = 0.9;
+  // Default style constants (used only as defaults in loadSettings)
+  const _defaultStrokeColor = '#E6E6E6';
+  const _defaultFillColor = '#E6E6E6';
+  const _defaultFillOpacity = 0.2;
+  const _defaultStrokeOpacity = 0.6;
+  const _defaultLabelColor = '#ffffff';
+  const _defaultLabelOutlineColor = '#000000';
+  const _defaultLabelFontSize = 12;
+  const _defaultLabelOutlineWidth = 2;
+  const _defaultHighlightColor = '#f7ad25';
   let currState = '';
   let currCity = [];
   let kmlCache = {};
+
+  // Screen polygon cache — rebuilt only when the map extent changes
+  let _cachedExtent = null;
+  let _cachedScreenPolygon = null;
+  let _cachedScreenArea = null;
 
   loadSettings();
 
@@ -174,11 +187,10 @@
     },
   };
 
-
   const _CA_States = {
     Alberta: 'AB',
     'British Columbia': 'BC',
-    'Manitoba': 'MB',
+    Manitoba: 'MB',
     'New Brunswick': 'NB',
     'Newfoundland and Labrador': 'NL',
     'Nova Scotia': 'NS',
@@ -220,6 +232,10 @@
     console.warn(`${scriptName}: SDK_INITIALIZED is undefined`);
   }
 
+  /**
+   * Acquires the WME SDK instance and waits for all three dependencies (WME, WazeWrap,
+   * GeoKMLer) to become ready in parallel before calling `init()`.
+   */
   function bootstrap() {
     wmeSDK = unsafeWindow.getWmeSdk({
       scriptId: scriptName.replaceAll(' ', ''),
@@ -238,6 +254,12 @@
       });
   }
 
+  /**
+   * Returns a Promise that resolves when the WME SDK and all required SDK sub-modules
+   * (Sidebar, LayerSwitcher, Shortcuts, Events) are fully loaded and ready.
+   *
+   * @returns {Promise<void>}
+   */
   function isWmeReady() {
     return new Promise((resolve, reject) => {
       if (wmeSDK && wmeSDK.State.isReady() && wmeSDK.Sidebar && wmeSDK.LayerSwitcher && wmeSDK.Shortcuts && wmeSDK.Events) {
@@ -261,6 +283,12 @@
     });
   }
 
+  /**
+   * Returns a Promise that resolves when the global `WazeWrap.Ready` flag is set.
+   * Polls every 500 ms for up to 1000 attempts before rejecting on timeout.
+   *
+   * @returns {Promise<void>}
+   */
   function isWazeWrapReady() {
     return new Promise((resolve, reject) => {
       const maxTries = 1000;
@@ -279,6 +307,12 @@
     });
   }
 
+  /**
+   * Returns a Promise that resolves when the globally injected `GeoKMLer` class is defined
+   * and can be successfully instantiated.
+   *
+   * @returns {Promise<void>}
+   */
   function isGeoKMLerReady() {
     return new Promise((resolve, reject) => {
       try {
@@ -300,42 +334,74 @@
     });
   }
 
-  function isChecked(checkboxId) {
-    return $('#' + checkboxId).is(':checked');
-  }
 
-  function setChecked(checkboxId, checked) {
-    $('#' + checkboxId).prop('checked', checked);
-  }
-
+  /**
+   * Loads persisted settings from localStorage into `_settings`, merging any missing
+   * keys with their default values so the settings object is always fully populated.
+   */
   function loadSettings() {
     _settings = $.parseJSON(localStorage.getItem(_settingsStoreName));
-    let _defaultsettings = {
+    const defaults = {
       layerVisible: true,
       ShowCityLabels: true,
       FillPolygons: true,
       HighlightFocusedCity: true,
       AutoUpdateKMLs: true,
+      strokeColor: _defaultStrokeColor,
+      fillColor: _defaultFillColor,
+      strokeOpacity: _defaultStrokeOpacity,
+      fillOpacity: _defaultFillOpacity,
+      labelColor: _defaultLabelColor,
+      labelColorMatchStroke: false,
+      labelOutlineColor: _defaultLabelOutlineColor,
+      labelOutlineColorMatchStroke: false,
+      labelFontSize: _defaultLabelFontSize,
+      labelFontSizeRelative: true,
+      labelOutlineWidth: _defaultLabelOutlineWidth,
+      labelOutlineWidthRelative: true,
+      highlightColor: _defaultHighlightColor,
     };
-    if (!_settings) _settings = _defaultsettings;
-    for (var prop in _defaultsettings) {
-      if (!_settings.hasOwnProperty(prop)) _settings[prop] = _defaultsettings[prop];
+    if (!_settings) _settings = defaults;
+    for (const prop in defaults) {
+      if (!Object.prototype.hasOwnProperty.call(_settings, prop)) _settings[prop] = defaults[prop];
     }
   }
 
+  /**
+   * Persists the current `_settings` values to localStorage as a JSON string.
+   */
   function saveSettings() {
     if (localStorage) {
-      var settings = {
+      const settings = {
         layerVisible: _settings.layerVisible,
         ShowCityLabels: _settings.ShowCityLabels,
         FillPolygons: _settings.FillPolygons,
         HighlightFocusedCity: _settings.HighlightFocusedCity,
         AutoUpdateKMLs: _settings.AutoUpdateKMLs,
+        strokeColor: _settings.strokeColor,
+        fillColor: _settings.fillColor,
+        strokeOpacity: _settings.strokeOpacity,
+        fillOpacity: _settings.fillOpacity,
+        labelColor: _settings.labelColor,
+        labelColorMatchStroke: _settings.labelColorMatchStroke,
+        labelOutlineColor: _settings.labelOutlineColor,
+        labelOutlineColorMatchStroke: _settings.labelOutlineColorMatchStroke,
+        labelFontSize: _settings.labelFontSize,
+        labelFontSizeRelative: _settings.labelFontSizeRelative,
+        labelOutlineWidth: _settings.labelOutlineWidth,
+        labelOutlineWidthRelative: _settings.labelOutlineWidthRelative,
       };
       localStorage.setItem(_settingsStoreName, JSON.stringify(settings));
     }
   }
 
+  /**
+   * Recursively removes the third (elevation/Z) value from a GeoJSON coordinate array,
+   * normalising all geometries to 2D [longitude, latitude] pairs.
+   *
+   * @param {Array} coordinates - A coordinate array at any nesting depth.
+   * @returns {Array} The same structure with every leaf coordinate truncated to [x, y].
+   */
   function stripElevation(coordinates) {
     if (Array.isArray(coordinates[0])) {
       // If coordinates are nested, recursively strip elevation
@@ -346,166 +412,50 @@
   }
 
   /**
-   * Function: flattenGeoJSON
-   * ------------------------
-   * Flattens a GeoJSON "FeatureCollection" into an array of individual GeoJSON features, ensuring consistent
-   * type casing and performing property cleanup, including the removal of unwanted characters.
+   * Converts a GeoJSON FeatureCollection into a flat array of simple-geometry Features.
+   * Multi-geometry types (MultiPolygon, MultiLineString, MultiPoint) and GeometryCollections
+   * are decomposed into individual Features via `turf.flattenEach`. Each feature's name
+   * property is cleaned of KML artefact characters and copied to `properties.labelText`.
+   * All coordinates are stripped to 2D using `stripElevation`.
    *
-   * Parameters:
-   * @param {Object} geoJson - The GeoJSON object to be flattened, expected to be a FeatureCollection.
-   * @returns {Array} - An array of individual GeoJSON features, each with cleaned properties and standardized types.
-   *
-   * Throws:
-   * - {Error} Throws an error if the GeoJSON input is invalid by not being a FeatureCollection.
-   *
-   * Description:
-   * - Processes a FeatureCollection by iterating over each feature using `geomEach` to handle various geometry types.
-   * - Geometry types such as MultiPoint, MultiLineString, and MultiPolygon are decomposed into individual features.
-   * - Cleans feature properties, stripping unwanted markers and creating a `labelText` from the `name` attribute.
-   * - Supports these GeoJSON geometry types: Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection.
-   *
-   * Internal Functions:
-   * - `updateGeoJSONType`: Ensures consistent casing of GeoJSON types using a lookup map.
-   * - `stripElevation`: Removes elevation data from coordinates for more straightforward processing.
-   *
-   * Example Usage:
-   * ```
-   * const flattenedFeatures = flattenGeoJSON(myGeoJSON);
-   * ```
+   * @param {Object} geoJson - A GeoJSON FeatureCollection.
+   * @returns {Array<Object>} Flat array of GeoJSON Feature objects ready for layer use.
+   * @throws {Error} If `geoJson` is not a valid FeatureCollection.
    */
   function flattenGeoJSON(geoJson) {
-    // Verify and extract features array from the input GeoJSON
     if (geoJson.type !== 'FeatureCollection' || !Array.isArray(geoJson.features)) {
       throw new Error('Invalid GeoJSON input: expected a FeatureCollection.');
     }
-
-    const features = geoJson.features;
-
-    const geoJSONTypeMap = {
-      FEATURECOLLECTION: 'FeatureCollection',
-      FEATURE: 'Feature',
-      GEOMETRYCOLLECTION: 'GeometryCollection',
-      POINT: 'Point',
-      LINESTRING: 'LineString',
-      POLYGON: 'Polygon',
-      MULTIPOINT: 'MultiPoint',
-      MULTILINESTRING: 'MultiLineString',
-      MULTIPOLYGON: 'MultiPolygon',
-    };
-
-    const updateGeoJSONType = (type) => geoJSONTypeMap[type.toUpperCase()] || type;
-
-    return features.flatMap((feature) => {
-      const flattenedGeometries = [];
-
+    const result = [];
+    turf.flattenEach(geoJson, (feature) => {
       if (feature.properties) {
-        const nameKey = ['name', 'Name', 'NAME'].find((key) => feature.properties[key]);
+        const nameKey = ['name', 'Name', 'NAME'].find((k) => feature.properties[k]);
         if (nameKey) {
-          feature.properties[nameKey] = feature.properties[nameKey].replace(/<at><openparen>/gi, '').replace(/<closeparen>/gi, '');
+          feature.properties[nameKey] = feature.properties[nameKey]
+            .replace(/<at><openparen>/gi, '')
+            .replace(/<closeparen>/gi, '');
           feature.properties.labelText = feature.properties[nameKey];
         }
       }
-
-      geomEach(feature.geometry, (geometry) => {
-        const type = geometry === null ? null : updateGeoJSONType(geometry.type);
-        switch (type) {
-          case 'Point':
-          case 'LineString':
-          case 'Polygon':
-            flattenedGeometries.push({
-              type: updateGeoJSONType('Feature'),
-              geometry: {
-                type: type,
-                coordinates: stripElevation(geometry.coordinates),
-              },
-              properties: feature.properties,
-            });
-            break;
-          case 'MultiPoint':
-          case 'MultiLineString':
-          case 'MultiPolygon':
-            const geomType = updateGeoJSONType(type.split('Multi')[1]);
-            geometry.coordinates.forEach((coordinate) => {
-              flattenedGeometries.push({
-                type: updateGeoJSONType('Feature'),
-                geometry: {
-                  type: geomType,
-                  coordinates: stripElevation(coordinate),
-                },
-                properties: feature.properties,
-              });
-            });
-            break;
-          case 'GeometryCollection':
-            geometry.geometries.forEach((geom) => {
-              const updatedType = updateGeoJSONType(geom.type);
-              flattenedGeometries.push({
-                type: updateGeoJSONType('Feature'),
-                geometry: {
-                  type: updatedType,
-                  coordinates: stripElevation(geom.coordinates),
-                },
-                properties: feature.properties,
-              });
-            });
-            break;
-          default:
-            throw new Error(`Unknown Geometry Type: ${type}`);
-        }
+      result.push({
+        type: 'Feature',
+        geometry: {
+          type: feature.geometry.type,
+          coordinates: stripElevation(feature.geometry.coordinates),
+        },
+        properties: feature.properties,
       });
-
-      return flattenedGeometries;
     });
+    return result;
   }
 
   /**
-   * Function: geomEach
-   * ------------------
-   * Iterates over each geometry within a feature, handling different types of geometries
-   * and their coordinate structures, and executing a specified callback function.
+   * Parses a KML string into a flat array of GeoJSON Features using the GeoKMLer library
+   * followed by `flattenGeoJSON` to normalise and decompose the result.
    *
-   * This function supports:
-   * - Simple geometries: Point, LineString, Polygon
-   * - Compound geometries: MultiPoint, MultiLineString, MultiPolygon
-   * - Geometry collections: GeometryCollection
-   *
-   * Parameters:
-   * @param {Object} geometry - The geometry object extracted from a feature, containing
-   *                            type and coordinates or sub-geometries.
-   * @param {Function} callback - A callback function to execute for each geometry type,
-   *                              receiving a geometry object as an argument.
-   *
-   * Notes:
-   * - For compound geometries, coordinates are processed individually, and elevation data
-   *   is stripped using `stripElevation`.
-   * - Throws an error if an unknown geometry type is encountered.
-   **/
-  function geomEach(geometry, callback) {
-    const type = geometry === null ? null : geometry.type;
-    switch (type) {
-      case 'Point':
-      case 'LineString':
-      case 'Polygon':
-        callback(geometry);
-        break;
-      case 'MultiPoint':
-      case 'MultiLineString':
-      case 'MultiPolygon':
-        geometry.coordinates.forEach((coordinate) => {
-          callback({
-            type: type.split('Multi')[1],
-            coordinates: stripElevation(coordinate), // Use stripElevation here
-          });
-        });
-        break;
-      case 'GeometryCollection':
-        geometry.geometries.forEach(callback);
-        break;
-      default:
-        throw new Error(`Unknown Geometry Type: ${type}`);
-    }
-  }
-
+   * @param {string} strKML - Raw KML document string.
+   * @returns {Array<Object>} Flat array of GeoJSON Feature objects.
+   */
   function GetFeaturesFromKMLString(strKML) {
     const geoKMLer = new GeoKMLer();
     const kmlDoc = geoKMLer.read(strKML);
@@ -562,12 +512,11 @@
 
     for (let i = 0; i < _layer.length; i++) {
       const feature = _layer[i];
-      const geometry = feature.geometry;
       const properties = feature.properties;
       const id = feature.id;
 
       // Check if the map center point is inside the feature's geometry (polygon)
-      if (isPointInPolygon(mapCenterPoint, geometry.coordinates[0])) {
+      if (turf.booleanPointInPolygon(turf.point(mapCenterPoint), feature)) {
         cityData.name = properties.name;
         cityData.featureId = id;
         if (debug) {
@@ -631,7 +580,7 @@
   async function updateCitiesLayer() {
     try {
       const zoom = wmeSDK.Map.getZoomLevel();
-      if (zoom < 12) {
+      if (zoom < 5) {
         return;
       }
 
@@ -642,7 +591,9 @@
       }
 
       if (currState !== topState.name) {
-        await updateCityPolygons();
+        await updateCityPolygons(); // loads polygons + calls refreshLabels internally
+      } else {
+        refreshLabels(); // same state — recompute labels for new viewport
       }
 
       currCity = findCurrCity();
@@ -659,6 +610,11 @@
     }
   }
 
+  /**
+   * Creates or refreshes the cyan city-name label injected into the WME
+   * location-info bar. Removes any existing label first, then appends a new one
+   * only when `_layer` has features and `currCity.name` is set.
+   */
   function updateDistrictNameDisplay() {
     // Remove existing district name displays
     $('.wmecitiesoverlay-region').remove();
@@ -686,28 +642,153 @@
   }
 
   /**
-   * Determines if a given point is inside a polygon using the ray-casting algorithm.
-   *
-   * This function checks whether a point, defined by its coordinates, is inside a polygon.
-   * The polygon is represented by an array of vertices (points), and the function uses the
-   * ray-casting technique to toggle the state whenever the ray crosses a polygon edge.
-   *
-   * @param {Array} point - An array [x, y] representing the coordinates of the point to test.
-   * @param {Array} vs - An array of vertices, where each vertex is represented as [x, y].
-   * @returns {boolean} - True if the point is inside the polygon, false otherwise.
-   **/
-  function isPointInPolygon(point, vs) {
-    const [x, y] = point;
-    let inside = false;
-    for (let i = 0, j = vs.length - 1; i < vs.length; j = i++) {
-      const [xi, yi] = vs[i];
-      const [xj, yj] = vs[j];
-      const intersect = yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi;
-      if (intersect) inside = !inside;
-    }
-    return inside;
+   * Clears all features from the polygon layer and re-adds the current `_layer` array,
+   * ensuring the map reflects the latest loaded city boundaries.
+   */
+  function addPolygonsToLayer() {
+    if (!_layer || !_layer.length) return;
+    wmeSDK.Map.removeAllFeaturesFromLayer({ layerName: layerid });
+    wmeSDK.Map.dangerouslyAddFeaturesToLayerWithoutValidation({
+      features: _layer,
+      layerName: layerid,
+    });
   }
 
+  /**
+   * Rebuilds the label layer for the current viewport. Clears existing label features,
+   * then for each city polygon that passes a fast bounding-box pre-filter, calls
+   * `getLabelPoints` to compute intersection-based label positions and adds them to the
+   * labels layer. Does nothing if labels are disabled or `_layer` is empty.
+   */
+  function refreshLabels() {
+    wmeSDK.Map.removeAllFeaturesFromLayer({ layerName: labelsLayerId });
+    if (!_settings.ShowCityLabels || !_layer || !_layer.length) return;
+
+    const ext = wmeSDK.Map.getMapExtent(); // [minX, minY, maxX, maxY]
+    const allLabels = [];
+
+    _layer.forEach((feature) => {
+      // Fast bbox pre-filter — skip turf.intersect for off-screen polygons
+      const b = feature.properties._bbox;
+      if (!b || b[0] > ext[2] || b[2] < ext[0] || b[1] > ext[3] || b[3] < ext[1]) return;
+
+      const points = getLabelPoints(feature);
+      if (points.length) allLabels.push(...points);
+    });
+
+    if (allLabels.length) {
+      wmeSDK.Map.dangerouslyAddFeaturesToLayerWithoutValidation({
+        features: allLabels,
+        layerName: labelsLayerId,
+      });
+    }
+  }
+
+  /**
+   * Computes label point Features for a single city polygon by intersecting it with
+   * the current screen viewport. Each intersection fragment larger than 0.5% of the
+   * screen area gets a label placed at its center-of-mass (or `pointOnFeature` as a
+   * fallback when the centroid falls outside the polygon).
+   *
+   * @param {Object} feature - A GeoJSON Feature with a Polygon geometry.
+   * @returns {Array<Object>} Array of GeoJSON Point Features (may be empty).
+   */
+  function getLabelPoints(feature) {
+    const screenPolygon = getScreenPolygon();
+    const intersection = turf.intersect(turf.featureCollection([screenPolygon, feature]));
+    const polygons = [];
+    if (intersection) {
+      switch (intersection.geometry.type) {
+        case 'Polygon':
+          polygons.push(intersection);
+          break;
+        case 'MultiPolygon':
+          intersection.geometry.coordinates.forEach((ring) => polygons.push(turf.polygon(ring)));
+          break;
+        default:
+          break;
+      }
+    }
+
+    const screenArea = getScreenArea();
+    return polygons
+      .filter((polygon) => {
+        const polygonArea = turf.area(polygon);
+        return polygonArea / screenArea > 0.005;
+      })
+      .map((polygon) => {
+        let point = turf.centerOfMass(polygon);
+        if (!turf.booleanPointInPolygon(point, polygon)) {
+          point = turf.pointOnFeature(polygon);
+        }
+        point.properties = { type: 'label', labelText: feature.properties.labelText };
+        point.id = 0;
+        return point;
+      });
+  }
+
+  /**
+   * Lazily rebuilds the screen-polygon and screen-area caches whenever the map extent
+   * changes. Called by `getScreenPolygon` and `getScreenArea` before returning their
+   * cached values, so callers always receive an up-to-date result without performing
+   * redundant recalculations on each label refresh.
+   */
+  function ensurePolygonCaches() {
+    const ext = wmeSDK.Map.getMapExtent();
+    if (
+      _cachedExtent &&
+      _cachedScreenPolygon &&
+      _cachedScreenArea !== null &&
+      _cachedExtent[0] === ext[0] &&
+      _cachedExtent[1] === ext[1] &&
+      _cachedExtent[2] === ext[2] &&
+      _cachedExtent[3] === ext[3]
+    ) {
+      return;
+    }
+    _cachedExtent = ext;
+    _cachedScreenPolygon = turf.polygon([
+      [
+        [ext[0], ext[3]],
+        [ext[2], ext[3]],
+        [ext[2], ext[1]],
+        [ext[0], ext[1]],
+        [ext[0], ext[3]],
+      ],
+    ]);
+    _cachedScreenArea = turf.area(_cachedScreenPolygon);
+  }
+
+  /**
+   * Returns the current viewport as a turf Polygon Feature, updating the cache first
+   * if the map extent has changed since the last call.
+   *
+   * @returns {Object} A turf Polygon Feature representing the visible map extent.
+   */
+  function getScreenPolygon() {
+    ensurePolygonCaches();
+    return _cachedScreenPolygon;
+  }
+
+  /**
+   * Returns the area of the current viewport in square metres, updating the cache first
+   * if the map extent has changed since the last call.
+   *
+   * @returns {number} Viewport area in m².
+   */
+  function getScreenArea() {
+    ensurePolygonCaches();
+    return _cachedScreenArea;
+  }
+
+  /**
+   * Performs a GET request via the Tampermonkey `GM_xmlhttpRequest` API, bypassing
+   * browser CORS restrictions for cross-origin GitHub raw-content URLs.
+   *
+   * @param {string} url - The URL to fetch.
+   * @returns {Promise<string>} Resolves with the response text, or rejects on HTTP 4xx/5xx
+   *   or network error.
+   */
   async function fetch(url) {
     //return await $.get(url);
     return new Promise((resolve, reject) => {
@@ -805,13 +886,19 @@
     updateCitiesLayer();
   }
 
+  /**
+   * Main initialisation routine. Registers the sidebar tab, creates the polygon and
+   * label map layers with their style rules, wires up event handlers, adds the layer
+   * switcher checkbox, and triggers the initial city polygon load if the layer is visible.
+   */
   async function init() {
     initTab();
     //I18n.translations[I18n.locale].layers.name[layerid] = "Cities Overlay";
     const layerConfig = {
       styleRules: [
         {
-          predicate: () => true,
+          // City polygons — stroke/fill only, no label text
+          predicate: (properties) => properties.type === 'city',
           style: {
             strokeDashstyle: 'solid',
             strokeColor: '${dynamicStrokeColor}',
@@ -819,57 +906,31 @@
             strokeWidth: '${dynamicStrokeWidth}',
             fillOpacity: '${dynamicFillOpacity}',
             fillColor: '${dynamicFillColor}',
-            fontColor: '#ffffff',
-            label: '${formatLabel}',
-            labelOutlineColor: '#000000',
-            labelOutlineWidth: 4,
-            labelAlign: 'cm',
-            fontSize: '16px',
+            label: '',
           },
         },
       ],
       styleContext: {
         dynamicStrokeColor: (context) => {
-          // Check if focused city highlighting is enabled and feature matches currCity
           if (_settings.HighlightFocusedCity && context.feature.id === currCity.featureId) {
-            return '#f7ad25'; // Highlight stroke color
+            return _settings.highlightColor;
           }
-          return _color; // Default stroke color
+          return _settings.strokeColor;
         },
         dynamicFillColor: (context) => {
-          // Check if focused city highlighting is enabled and feature matches currCity
           if (_settings.HighlightFocusedCity && context.feature.id === currCity.featureId) {
-            return '#f7ad25'; // Highlight fill color
+            return _settings.highlightColor;
           }
-          return _color; // Default fill color
+          return _settings.fillColor;
         },
         dynamicStrokeWidth: (context) => {
-          // Increase stroke width if focused city highlighting is enabled and feature matches currCity
           if (_settings.HighlightFocusedCity && context.feature.id === currCity.featureId) {
             return 6; // Highlight stroke width
           }
-          return 2; // Default stroke width
+          return 2;
         },
-        dynamicStrokeOpacity: () => {
-          return _settings.FillPolygons ? defaultStrokeOpacity : noFillStrokeOpacity;
-        },
-        dynamicFillOpacity: () => {
-          return _settings.FillPolygons ? defaultFillOpacity : 0;
-        },
-        formatLabel: (context) => {
-          let labelTemplate = '';
-          if (!_settings.ShowCityLabels) {
-            return ''; // Skip rendering if disabled in settings
-          }
-          // Confirm necessary properties exist in the context
-          if (!context || !context.feature || !context.feature.properties || !context.feature.properties.labelText) {
-            console.error(`${scriptName}: Invalid context or missing 'labelText' property.`);
-            return '';
-          }
-          // Direct assignment of label text
-          labelTemplate = context.feature.properties.labelText.trim();
-          return labelTemplate; // Return trimmed label for display
-        },
+        dynamicStrokeOpacity: () => _settings.strokeOpacity,
+        dynamicFillOpacity: () => (_settings.FillPolygons ? _settings.fillOpacity : 0),
       },
     };
 
@@ -880,8 +941,53 @@
       zIndexing: true,
     });
 
+    // Labels layer — registered after polygon layer so it always renders on top
+    wmeSDK.Map.addLayer({
+      layerName: labelsLayerId,
+      styleRules: [
+        {
+          predicate: (properties) => properties.type === 'label',
+          style: {
+            pointRadius: 0,
+            label: '${getLabel}',
+            fontSize: '${getFontSize}',
+            fontFamily: 'Arial',
+            fontWeight: 'bold',
+            fontColor: '${getFontColor}',
+            labelOutlineColor: '${getLabelOutlineColor}',
+            labelOutlineWidth: '${getLabelOutlineWidth}',
+            labelYOffset: '${getLabelYOffset}',
+            labelAlign: 'cm',
+          },
+        },
+      ],
+      styleContext: {
+        getLabel: ({ feature, zoomLevel }) => {
+          if (zoomLevel < 12) return '';
+          return feature?.properties?.labelText?.trim() ?? '';
+        },
+        getFontSize: ({ zoomLevel }) => {
+          if (_settings.labelFontSizeRelative) return `${Math.round(20 + (zoomLevel - 12) * 2)}px`;
+          return `${_settings.labelFontSize}px`;
+        },
+        getFontColor: () => (_settings.labelColorMatchStroke ? _settings.strokeColor : _settings.labelColor),
+        getLabelOutlineColor: () => (_settings.labelOutlineColorMatchStroke ? _settings.strokeColor : _settings.labelOutlineColor),
+        getLabelOutlineWidth: ({ zoomLevel }) => {
+          if (_settings.labelOutlineWidthRelative) return Math.max(1, Math.round((zoomLevel + 2) / 8));
+          return _settings.labelOutlineWidth;
+        },
+        getLabelYOffset: ({ zoomLevel }) => {
+          if (zoomLevel < 15) return 0;
+          if (zoomLevel < 18) return 5;
+          return 10;
+        },
+      },
+      zIndexing: true,
+    });
+
     // Set visibility to true for the layer
     wmeSDK.Map.setLayerVisibility({ layerName: layerid, visibility: _settings.layerVisible });
+    wmeSDK.Map.setLayerVisibility({ layerName: labelsLayerId, visibility: _settings.layerVisible });
     wmeSDK.LayerSwitcher.addLayerCheckbox({ name: 'Cities Overlay' });
     wmeSDK.LayerSwitcher.setLayerCheckboxChecked({ name: 'Cities Overlay', isChecked: _settings.layerVisible });
     wmeSDK.Events.on({ eventName: 'wme-layer-checkbox-toggled', eventHandler: layerToggled });
@@ -896,163 +1002,628 @@
     }
   } // END int() function
 
+  /**
+   * Builds and registers the script's sidebar panel. Injects scoped CSS, then constructs
+   * the Display, Polygon Style, Label Style, and Database cards along with the Quick Presets
+   * chip bar. Defines all inner UI-helper functions and wires their event listeners.
+   */
   function initTab() {
-    // Create the section element using jQuery
-    var $section = $('<div>', {
-      style: 'padding:8px 16px',
-      id: 'WMECitiesOverlaySettings',
-    });
-
-    // Function to inject custom CSS
-    function addCustomStyles() {
+    // Inject scoped styles
+    if (!document.getElementById('wme-cities-styles')) {
       const style = document.createElement('style');
+      style.id = 'wme-cities-styles';
       style.textContent = `
-    .wmecoSettingsCheckbox {
-      margin-right: 5px;  /* Adds space to the right of the checkbox */
-      cursor: pointer;  /* Pointer indicates interactivity */
-      appearance: none;  /* Remove default styling */
-      width: 16px;  /* Width of checkbox */
-      height: 16px;  /* Height of checkbox */
-      background-color: #e0e0e0;  /* Light gray background for unselected state */
-      border: 2px solid #bbb;  /* Soft border */
-      border-radius: 4px;  /* Slight rounded corners */
-      position: relative;  /* Position relative for inner elements */
-      transition: all 0.3s ease;  /* Smooth transition for hover effects */
-      box-shadow: 0 2px 5px rgba(0,0,0,0.15);  /* Adds a subtle shadow */
-    }
-    
-    .wmecoSettingsCheckbox:hover {
-      background-color: #d1d1d1;  /* Slightly darker on hover */
-      border-color: #999;  /* Darker border on hover */
-      margin-right: 5px;
-
-    }
-    
-    .wmecoSettingsCheckbox:checked {
-      background-color: #4caf50;  /* Green background for checked state */
-      border-color: #3e8e41;  /* Darker green border for checked */
-      margin-right: 5px;
-    }
-    
-    .wmecoSettingsCheckbox:checked::after {
-      content: '';  /* Content for checkmark */
-      position: absolute;
-      left: 4px;  /* Horizontal position for checkmark */
-      top: 0px;  /* Vertical position for checkmark */
-      width: 12px;  /* Width of checkmark */
-      height: 12px;  /* Height of checkmark */
-      border: solid white;  /* White checkmark */
-      border-width: 0 3px 3px 0;
-      transform: rotate(45deg);  /* Rotation to create checkmark */
-      margin-right: 5px;
-    }
-  `;
+.wme-cities-panel { font-family: inherit; font-size: 12px; line-height: 1.4; color: var(--content_default); padding: 4px; box-sizing: border-box; }
+.wme-cities-panel .co-header { background: linear-gradient(135deg, #0066cc, #0052a3); padding: 8px 10px; border-radius: 8px; margin-bottom: 8px; display: flex; align-items: center; justify-content: space-between; color: white; }
+.wme-cities-panel .co-title { font-size: 13px; font-weight: 700; letter-spacing: 0.3px; }
+.wme-cities-panel .co-version { font-size: 10px; opacity: 0.8; }
+.wme-cities-panel .co-card { background: var(--background_default); border: 1px solid var(--hairline); border-radius: 8px; padding: 8px 10px; margin-bottom: 8px; }
+.wme-cities-panel .co-card-title { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px; color: var(--primary); margin-bottom: 8px; padding-bottom: 4px; border-bottom: 1px solid var(--hairline); }
+.wme-cities-panel .co-row { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
+.wme-cities-panel .co-row:last-child { margin-bottom: 0; }
+.wme-cities-panel .co-label { font-size: 11px; font-weight: 500; color: var(--content_p1); flex: 1; }
+.wme-cities-panel .co-toggle-wrap { position: relative; display: inline-block; width: 32px; height: 16px; cursor: pointer; flex-shrink: 0; }
+.wme-cities-panel .co-toggle-wrap input { opacity: 0; width: 0; height: 0; position: absolute; }
+.wme-cities-panel .co-toggle-slider { position: absolute; top: 0; left: 0; right: 0; bottom: 0; background: var(--hairline); border-radius: 8px; transition: background 0.25s; }
+.wme-cities-panel .co-toggle-slider::before { position: absolute; content: ''; height: 12px; width: 12px; left: 2px; bottom: 2px; background: white; border-radius: 50%; transition: transform 0.25s; box-shadow: 0 1px 2px rgba(0,0,0,0.3); }
+.wme-cities-panel .co-toggle-wrap input:checked + .co-toggle-slider { background: var(--primary, #4a90e2); }
+.wme-cities-panel .co-toggle-wrap input:checked + .co-toggle-slider::before { transform: translateX(16px); }
+.wme-cities-panel .co-color-btn { width: 36px; height: 22px; padding: 0 2px; border: 1px solid var(--hairline); border-radius: 4px; cursor: pointer; flex-shrink: 0; }
+.wme-cities-panel .co-slider-row { margin-bottom: 8px; }
+.wme-cities-panel .co-slider-row:last-child { margin-bottom: 0; }
+.wme-cities-panel .co-slider-label { display: flex; justify-content: space-between; font-size: 11px; color: var(--content_p1); margin-bottom: 3px; font-weight: 500; }
+.wme-cities-panel .co-slider { width: 100%; height: 5px; -webkit-appearance: none; appearance: none; border-radius: 3px; outline: none; cursor: pointer; }
+.wme-cities-panel .co-slider::-webkit-slider-thumb { -webkit-appearance: none; width: 14px; height: 14px; background: var(--primary, #4a90e2); cursor: pointer; border-radius: 50%; box-shadow: 0 1px 3px rgba(0,0,0,0.3); margin-top: -4.5px; }
+.wme-cities-panel .co-slider::-moz-range-thumb { width: 14px; height: 14px; background: var(--primary, #4a90e2); cursor: pointer; border-radius: 50%; border: none; box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
+.wme-cities-panel .co-slider-presets { display: flex; gap: 4px; margin-top: 5px; }
+.wme-cities-panel .co-preset { padding: 2px 7px; font-size: 10px; font-weight: 600; border: 1px solid var(--hairline); border-radius: 10px; background: var(--background_default); color: var(--content_p1); cursor: pointer; transition: all 0.15s; }
+.wme-cities-panel .co-preset:hover { background: var(--primary, #4a90e2); color: white; border-color: var(--primary, #4a90e2); }
+.wme-cities-panel .co-btn { display: block; width: 100%; padding: 6px 10px; font-size: 11px; font-weight: 600; border: none; border-radius: 6px; cursor: pointer; background: var(--primary, #4a90e2); color: white !important; box-sizing: border-box; transition: opacity 0.2s; margin-top: 6px; }
+.wme-cities-panel .co-btn:hover { opacity: 0.85; }
+.wme-cities-panel .co-status { font-size: 10px; color: var(--content_p2); margin-top: 4px; min-height: 14px; }
+.wme-cities-panel .co-quick-presets { background: var(--surface_variant, #f0f0f0); padding: 10px 12px; border-radius: 8px; margin-bottom: 10px; }
+.wme-cities-panel .co-presets-label { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: var(--content_p2); margin-bottom: 8px; display: block; }
+.wme-cities-panel .co-preset-chips { display: flex; gap: 6px; flex-wrap: wrap; }
+.wme-cities-panel .co-preset-chip { padding: 5px 10px; background: var(--background_default); border: 1px solid var(--hairline); border-radius: 14px; font-size: 11px; font-weight: 500; color: var(--content_p1); cursor: pointer; transition: all 150ms ease; white-space: nowrap; }
+.wme-cities-panel .co-preset-chip:hover { background: var(--primary, #4a90e2); color: white; border-color: var(--primary, #4a90e2); }
+.wme-cities-panel .co-toggle-text { font-size: 10px; color: var(--content_p2); white-space: nowrap; flex-shrink: 0; }
+.wme-cities-panel .co-number-input { width: 52px; padding: 2px 5px; border: 1px solid var(--hairline); border-radius: 4px; font-size: 11px; background: var(--surface_default); color: var(--content_default); text-align: center; flex-shrink: 0; }
+.wme-cities-panel .co-number-input:disabled { opacity: 0.4; cursor: not-allowed; }
+      `;
       document.head.appendChild(style);
     }
 
-    // Append the HTML content to the section
-    $section.append(
-      `<h4 style="margin-bottom:0px;">
-    <i id="citiesPower" class="fa fa-power-off" aria-hidden="true" 
-       style="color:${_settings.layerVisible ? 'rgb(0,180,0)' : 'rgb(255, 0, 0)'}; cursor:pointer;">
-    </i> 
-    <b>WME Cities Overlay</b>
-  </h4>`,
-      `<h6 style="margin-top:0px;">${GM_info.script.version}</h6>`,
-      '<div id="divWMECOFillPolygons"><input type="checkbox" id="_cbCOFillPolygons" class="wmecoSettingsCheckbox" /><label for="_cbCOFillPolygons">Fill polygons</label></div>',
-      '<div id="divWMECOShowCityLabels"><input type="checkbox" id="_cbCOShowCityLabels" class="wmecoSettingsCheckbox" /><label for="_cbCOShowCityLabels">Show city labels</label></div>',
-      '<div id="divWMECOHighlightFocusedCity"><input type="checkbox" id="_cbCOHighlightFocusedCity" class="wmecoSettingsCheckbox" /><label for="_cbCOHighlightFocusedCity">Highlight focused city</label></div>',
-      '<fieldset id="fieldUpdates" style="border: 1px solid silver; padding: 8px; border-radius: 4px;">' +
-        '<legend style="margin-bottom:0px; border-bottom-style:none;width:auto;"><h4>Update Settings</h4></legend>' +
-        '<div id="divWMECOUpdateMaps" title="Checks for new state files for the current country"><button id="WMECOupdateMaps" type="button">Refresh / Update database</button></div>' +
-        '<div id="WMECOupdateStatus"></div>' +
-        '<div id="divWMECOAutoUpdateKMLs" title="Checks for updated state files for the current country when WME loads"><input type="checkbox" id="_cbCOAutoUpdateKMLs" class="wmecoSettingsCheckbox" /><label for="_cbCOAutoUpdateKMLs">Automatically update database</label></div>' +
-        '</fieldset>'
-    );
+    /**
+     * Updates a range slider's fill gradient and its sibling percentage label to match
+     * the slider's current value.
+     *
+     * @param {HTMLInputElement} slider - The range input element to update.
+     */
+    function updateSlider(slider) {
+      const pct = Math.round(parseFloat(slider.value) * 100);
+      slider.style.background = `linear-gradient(to right, #4a90e2 0%, #4a90e2 ${pct}%, #e1e4e8 ${pct}%, #e1e4e8 100%)`;
+      const valueEl = slider.parentElement && slider.parentElement.querySelector('.co-slider-value');
+      if (valueEl) valueEl.textContent = `${pct}%`;
+    }
 
-    // Add styles
-    addCustomStyles();
+    /**
+     * Creates a styled CSS toggle-switch control.
+     *
+     * @param {boolean} checked - Initial checked state.
+     * @param {Function} onChange - Callback invoked with the new boolean value on change.
+     * @returns {HTMLLabelElement} The toggle wrapper element.
+     */
+    function makeToggle(checked, onChange) {
+      const wrap = document.createElement('label');
+      wrap.className = 'co-toggle-wrap';
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.checked = checked;
+      input.addEventListener('change', () => onChange(input.checked));
+      const slider = document.createElement('span');
+      slider.className = 'co-toggle-slider';
+      wrap.appendChild(input);
+      wrap.appendChild(slider);
+      return wrap;
+    }
 
-    // Register the script tab with the sidebar
+    /**
+     * Creates a two-column settings row containing a label on the left and an arbitrary
+     * control element on the right.
+     *
+     * @param {string} labelText - Display text for the row label.
+     * @param {HTMLElement} control - The input or toggle element to place on the right.
+     * @returns {HTMLDivElement} The row div.
+     */
+    function makeRow(labelText, control) {
+      const row = document.createElement('div');
+      row.className = 'co-row';
+      const label = document.createElement('span');
+      label.className = 'co-label';
+      label.textContent = labelText;
+      row.appendChild(label);
+      row.appendChild(control);
+      return row;
+    }
+
+    /**
+     * Creates a complete opacity slider row with a label, live percentage readout, a
+     * range input, and a row of quick-select preset buttons.
+     *
+     * @param {string} labelText - Display label for the slider (e.g. "Stroke Opacity").
+     * @param {string} settingKey - The `_settings` key updated when the slider changes.
+     * @param {number} value - Initial slider value in the range [0, 1].
+     * @returns {HTMLDivElement} The slider row wrapper element.
+     */
+    function makeSliderRow(labelText, settingKey, value) {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'co-slider-row';
+
+      const labelRow = document.createElement('div');
+      labelRow.className = 'co-slider-label';
+      const labelSpan = document.createElement('span');
+      labelSpan.textContent = labelText;
+      const valueSpan = document.createElement('span');
+      valueSpan.className = 'co-slider-value';
+      valueSpan.textContent = `${Math.round(value * 100)}%`;
+      labelRow.appendChild(labelSpan);
+      labelRow.appendChild(valueSpan);
+      wrapper.appendChild(labelRow);
+
+      const slider = document.createElement('input');
+      slider.type = 'range';
+      slider.className = 'co-slider';
+      slider.min = '0';
+      slider.max = '1';
+      slider.step = '0.05';
+      slider.value = value;
+      updateSlider(slider);
+
+      slider.addEventListener('input', () => {
+        const val = parseFloat(slider.value);
+        _settings[settingKey] = val;
+        updateSlider(slider);
+        saveSettings();
+        wmeSDK.Map.redrawLayer({ layerName: layerid });
+      });
+      wrapper.appendChild(slider);
+
+      const presets = document.createElement('div');
+      presets.className = 'co-slider-presets';
+      [0.05, 0.1, 0.15, 0.2, 0.25, 0.5, 0.75].forEach((val) => {
+        const btn = document.createElement('button');
+        btn.className = 'co-preset';
+        btn.textContent = `${val * 100}%`;
+        btn.addEventListener('click', () => {
+          slider.value = val;
+          _settings[settingKey] = val;
+          updateSlider(slider);
+          saveSettings();
+          wmeSDK.Map.redrawLayer({ layerName: layerid });
+        });
+        presets.appendChild(btn);
+      });
+      wrapper.appendChild(presets);
+
+      return wrapper;
+    }
+
     wmeSDK.Sidebar.registerScriptTab()
       .then(({ tabLabel, tabPane }) => {
-        // Set the tab label and title
-        tabLabel.textContent = 'Cities';
-        tabLabel.title = scriptName;
+        const powerBtnColor = _settings.layerVisible ? '#00bd00' : '#ccc';
+        tabLabel.innerHTML = `<span id="cities-overlay-power-btn" class="fa fa-power-off" title="Toggle Cities Overlay" style="margin-right:5px;cursor:pointer;color:${powerBtnColor};font-size:13px;"></span><span title="${scriptName}">Cities</span>`;
+        $('#cities-overlay-power-btn').on('click', function () {
+          setLayerVisible(!_settings.layerVisible);
+          return false;
+        });
+        tabPane.classList.add('wme-cities-panel');
 
-        // Append the section to the tab pane
-        tabPane.appendChild($section.get(0));
+        // Header
+        const header = document.createElement('div');
+        header.className = 'co-header';
+        header.innerHTML = `<span class="co-title">Cities Overlay</span><span class="co-version">v${GM_info.script.version}</span>`;
+        tabPane.appendChild(header);
 
-        // Set initial checkbox states based on settings
-        setChecked('_cbCOShowCityLabels', _settings.ShowCityLabels);
-        setChecked('_cbCOFillPolygons', _settings.FillPolygons);
-        setChecked('_cbCOHighlightFocusedCity', _settings.HighlightFocusedCity);
-        setChecked('_cbCOAutoUpdateKMLs', _settings.AutoUpdateKMLs);
+        // Quick Presets — chips wired after all style card refs are built below
+        const presetsDiv = document.createElement('div');
+        presetsDiv.className = 'co-quick-presets';
+        const presetsLabel = document.createElement('span');
+        presetsLabel.className = 'co-presets-label';
+        presetsLabel.textContent = 'Quick Presets';
+        presetsDiv.appendChild(presetsLabel);
+        const presetsChips = document.createElement('div');
+        presetsChips.className = 'co-preset-chips';
+        [
+          { key: 'default', label: 'Default' },
+          { key: 'high-contrast', label: 'High Contrast' },
+          { key: 'minimal', label: 'Minimal' },
+          { key: 'colorblind', label: 'Colorblind' },
+          { key: 'night', label: 'Night Mode' },
+        ].forEach(({ key, label }) => {
+          const chip = document.createElement('div');
+          chip.className = 'co-preset-chip';
+          chip.dataset.preset = key;
+          chip.textContent = label;
+          presetsChips.appendChild(chip);
+        });
+        presetsDiv.appendChild(presetsChips);
+        tabPane.appendChild(presetsDiv);
 
-        // Add event listeners
-        $('.wmecoSettingsCheckbox').change(function () {
-          var settingName = $(this)[0].id.substr(5);
-          _settings[settingName] = this.checked;
+        // Display card
+        const displayCard = document.createElement('div');
+        displayCard.className = 'co-card';
+        const displayTitle = document.createElement('div');
+        displayTitle.className = 'co-card-title';
+        displayTitle.textContent = 'Display';
+        displayCard.appendChild(displayTitle);
+
+        displayCard.appendChild(
+          makeRow(
+            'Fill Polygons',
+            makeToggle(_settings.FillPolygons, (checked) => {
+              _settings.FillPolygons = checked;
+              saveSettings();
+              wmeSDK.Map.redrawLayer({ layerName: layerid });
+            }),
+          ),
+        );
+
+        displayCard.appendChild(
+          makeRow(
+            'Show City Labels',
+            makeToggle(_settings.ShowCityLabels, (checked) => {
+              _settings.ShowCityLabels = checked;
+              saveSettings();
+              refreshLabels();
+            }),
+          ),
+        );
+
+        displayCard.appendChild(
+          makeRow(
+            'Highlight Focused City',
+            makeToggle(_settings.HighlightFocusedCity, (checked) => {
+              _settings.HighlightFocusedCity = checked;
+              saveSettings();
+              wmeSDK.Map.redrawLayer({ layerName: layerid });
+            }),
+          ),
+        );
+
+        tabPane.appendChild(displayCard);
+
+        // Style card
+        const styleCard = document.createElement('div');
+        styleCard.className = 'co-card';
+        const styleTitle = document.createElement('div');
+        styleTitle.className = 'co-card-title';
+        styleTitle.textContent = 'Polygon Style';
+        styleCard.appendChild(styleTitle);
+
+        const strokeColorInput = document.createElement('input');
+        strokeColorInput.type = 'color';
+        strokeColorInput.className = 'co-color-btn';
+        strokeColorInput.value = _settings.strokeColor;
+        strokeColorInput.addEventListener('input', () => {
+          _settings.strokeColor = strokeColorInput.value;
           saveSettings();
+          wmeSDK.Map.redrawLayer({ layerName: layerid });
+          wmeSDK.Map.redrawLayer({ layerName: labelsLayerId });
+          // Keep synced label color pickers in step with the new stroke color
+          if (_settings.labelColorMatchStroke) labelColorInput.value = _settings.strokeColor;
+          if (_settings.labelOutlineColorMatchStroke) outlineColorInput.value = _settings.strokeColor;
         });
+        styleCard.appendChild(makeRow('Stroke Color', strokeColorInput));
 
-        $('#citiesPower').click(function () {
-          layerToggled();
-        });
-
-        $('#WMECOupdateMaps').click(updateAllMaps);
-
-        $('#_cbCOFillPolygons').change(function () {
-          _settings.FillPolygons = this.checked;
+        const fillColorInput = document.createElement('input');
+        fillColorInput.type = 'color';
+        fillColorInput.className = 'co-color-btn';
+        fillColorInput.value = _settings.fillColor;
+        fillColorInput.addEventListener('input', () => {
+          _settings.fillColor = fillColorInput.value;
           saveSettings();
           wmeSDK.Map.redrawLayer({ layerName: layerid });
         });
+        styleCard.appendChild(makeRow('Fill Color', fillColorInput));
 
-        $('#_cbCOShowCityLabels').change(function () {
-          _settings.ShowCityLabels = this.checked;
+        styleCard.appendChild(makeSliderRow('Stroke Opacity', 'strokeOpacity', _settings.strokeOpacity));
+        styleCard.appendChild(makeSliderRow('Fill Opacity', 'fillOpacity', _settings.fillOpacity));
+
+        tabPane.appendChild(styleCard);
+
+        // Label Style card
+        const labelCard = document.createElement('div');
+        labelCard.className = 'co-card';
+        const labelCardTitle = document.createElement('div');
+        labelCardTitle.className = 'co-card-title';
+        labelCardTitle.textContent = 'Label Style';
+        labelCard.appendChild(labelCardTitle);
+
+        /**
+         * Creates a label-style color row with a colour picker and a sync toggle that, when
+         * enabled, locks the colour to match the current stroke colour.
+         *
+         * @param {string} labelText - Display label for the row.
+         * @param {string} colorSetting - The `_settings` key for the colour value.
+         * @param {string} syncSetting - The `_settings` key for the sync-to-stroke boolean.
+         * @returns {{ row: HTMLDivElement, colorInput: HTMLInputElement, syncToggle: HTMLLabelElement }}
+         */
+        function makeColorSyncRow(labelText, colorSetting, syncSetting) {
+          const row = document.createElement('div');
+          row.className = 'co-row';
+
+          const lbl = document.createElement('span');
+          lbl.className = 'co-label';
+          lbl.textContent = labelText;
+
+          const colorInput = document.createElement('input');
+          colorInput.type = 'color';
+          colorInput.className = 'co-color-btn';
+          // Show stroke color in the picker when sync is already on
+          colorInput.value = _settings[syncSetting] ? _settings.strokeColor : _settings[colorSetting];
+          colorInput.disabled = _settings[syncSetting];
+
+          const syncToggle = makeToggle(_settings[syncSetting], (checked) => {
+            _settings[syncSetting] = checked;
+            colorInput.disabled = checked;
+            if (checked) colorInput.value = _settings.strokeColor; // reflect current stroke color
+            saveSettings();
+            wmeSDK.Map.redrawLayer({ layerName: labelsLayerId });
+          });
+
+          const syncLabel = document.createElement('span');
+          syncLabel.className = 'co-toggle-text';
+          syncLabel.textContent = 'Stroke';
+
+          colorInput.addEventListener('input', () => {
+            _settings[colorSetting] = colorInput.value;
+            saveSettings();
+            wmeSDK.Map.redrawLayer({ layerName: labelsLayerId });
+          });
+
+          row.appendChild(lbl);
+          row.appendChild(colorInput);
+          row.appendChild(syncToggle);
+          row.appendChild(syncLabel);
+          return { row, colorInput, syncToggle };
+        }
+
+        const { row: labelColorRow, colorInput: labelColorInput, syncToggle: labelColorSyncToggle } = makeColorSyncRow('Label Color', 'labelColor', 'labelColorMatchStroke');
+        labelCard.appendChild(labelColorRow);
+        const { row: outlineColorRow, colorInput: outlineColorInput, syncToggle: outlineColorSyncToggle } = makeColorSyncRow('Outline Color', 'labelOutlineColor', 'labelOutlineColorMatchStroke');
+        labelCard.appendChild(outlineColorRow);
+
+        /**
+         * Creates a numeric input row with a constrained number field and an "auto" toggle
+         * that, when enabled, disables the manual input and uses a zoom-relative formula
+         * instead.
+         *
+         * @param {string} labelText - Display label for the row.
+         * @param {string} numSetting - The `_settings` key for the numeric value.
+         * @param {string} autoSetting - The `_settings` key for the auto/relative boolean.
+         * @param {number} min - Minimum allowed value for the number input.
+         * @param {number} max - Maximum allowed value for the number input.
+         * @param {number} step - Step increment for the number input.
+         * @param {string} autoText - Label text shown next to the auto toggle (e.g. "Auto").
+         * @returns {{ row: HTMLDivElement, numInput: HTMLInputElement, autoToggle: HTMLLabelElement }}
+         */
+        function makeNumberAutoRow(labelText, numSetting, autoSetting, min, max, step, autoText) {
+          const row = document.createElement('div');
+          row.className = 'co-row';
+
+          const lbl = document.createElement('span');
+          lbl.className = 'co-label';
+          lbl.textContent = labelText;
+
+          const numInput = document.createElement('input');
+          numInput.type = 'number';
+          numInput.className = 'co-number-input';
+          numInput.min = min;
+          numInput.max = max;
+          numInput.step = step;
+          numInput.value = _settings[numSetting];
+          numInput.disabled = _settings[autoSetting];
+
+          const autoToggle = makeToggle(_settings[autoSetting], (checked) => {
+            _settings[autoSetting] = checked;
+            numInput.disabled = checked;
+            saveSettings();
+            wmeSDK.Map.redrawLayer({ layerName: labelsLayerId });
+          });
+
+          const autoLabel = document.createElement('span');
+          autoLabel.className = 'co-toggle-text';
+          autoLabel.textContent = autoText;
+
+          numInput.addEventListener('change', () => {
+            _settings[numSetting] = parseFloat(numInput.value);
+            saveSettings();
+            wmeSDK.Map.redrawLayer({ layerName: labelsLayerId });
+          });
+
+          row.appendChild(lbl);
+          row.appendChild(numInput);
+          row.appendChild(autoToggle);
+          row.appendChild(autoLabel);
+          return { row, numInput, autoToggle };
+        }
+
+        const { row: fontSizeRow, numInput: fontSizeNumInput, autoToggle: fontSizeAutoToggle } = makeNumberAutoRow('Font Size (px)', 'labelFontSize', 'labelFontSizeRelative', 6, 32, 1, 'Auto');
+        labelCard.appendChild(fontSizeRow);
+        const {
+          row: outlineWidthRow,
+          numInput: outlineWidthNumInput,
+          autoToggle: outlineWidthAutoToggle,
+        } = makeNumberAutoRow('Outline Width', 'labelOutlineWidth', 'labelOutlineWidthRelative', 1, 10, 1, 'Auto');
+        labelCard.appendChild(outlineWidthRow);
+
+        tabPane.appendChild(labelCard);
+
+        // Quick Preset definitions — every key fully specified for consistent, predictable results
+        const PRESETS = {
+          // Factory defaults
+          default: {
+            strokeColor: _defaultStrokeColor,
+            fillColor: _defaultFillColor,
+            strokeOpacity: _defaultStrokeOpacity,
+            fillOpacity: _defaultFillOpacity,
+            labelColor: _defaultLabelColor,
+            labelColorMatchStroke: false,
+            labelOutlineColor: _defaultLabelOutlineColor,
+            labelOutlineColorMatchStroke: false,
+            labelFontSize: _defaultLabelFontSize,
+            labelFontSizeRelative: true,
+            labelOutlineWidth: _defaultLabelOutlineWidth,
+            labelOutlineWidthRelative: true,
+            highlightColor: _defaultHighlightColor,
+          },
+          // Matches USGB Counties — bright yellow, high opacity
+          // Highlight is orange-red so it stands out against yellow polygons
+          'high-contrast': {
+            strokeColor: '#ffff00',
+            fillColor: '#ffff00',
+            strokeOpacity: 0.9,
+            fillOpacity: 0.1,
+            labelColor: '#ffff00',
+            labelColorMatchStroke: true,
+            labelOutlineColor: _defaultLabelOutlineColor,
+            labelOutlineColorMatchStroke: false,
+            labelFontSize: _defaultLabelFontSize,
+            labelFontSizeRelative: true,
+            labelOutlineWidth: _defaultLabelOutlineWidth,
+            labelOutlineWidthRelative: true,
+            highlightColor: '#FF4500',
+          },
+          // Matches USGB Counties — reduced opacity, muted gray
+          minimal: {
+            strokeColor: '#AAAAAA',
+            fillColor: '#AAAAAA',
+            strokeOpacity: 0.3,
+            fillOpacity: 0.1,
+            labelColor: _defaultLabelColor,
+            labelColorMatchStroke: false,
+            labelOutlineColor: _defaultLabelOutlineColor,
+            labelOutlineColorMatchStroke: false,
+            labelFontSize: _defaultLabelFontSize,
+            labelFontSizeRelative: true,
+            labelOutlineWidth: _defaultLabelOutlineWidth,
+            labelOutlineWidthRelative: true,
+            highlightColor: _defaultHighlightColor,
+          },
+          // Matches USGB Counties — IBM colorblind-safe amber
+          // Highlight is pink (also IBM colorblind-safe, contrasts with amber)
+          colorblind: {
+            strokeColor: '#DE8F05',
+            fillColor: '#DE8F05',
+            strokeOpacity: _defaultStrokeOpacity,
+            fillOpacity: 0.15,
+            labelColor: '#DE8F05',
+            labelColorMatchStroke: true,
+            labelOutlineColor: _defaultLabelOutlineColor,
+            labelOutlineColorMatchStroke: false,
+            labelFontSize: _defaultLabelFontSize,
+            labelFontSizeRelative: true,
+            labelOutlineWidth: _defaultLabelOutlineWidth,
+            labelOutlineWidthRelative: true,
+            highlightColor: '#CC78BC',
+          },
+          // Matches USGB Counties — deep indigo, reduced opacity
+          // White labels with black outline stay readable on dark maps
+          night: {
+            strokeColor: '#4B0082',
+            fillColor: '#4B0082',
+            strokeOpacity: 0.7,
+            fillOpacity: 0.15,
+            labelColor: '#4B0082',
+            labelColorMatchStroke: true,
+            labelOutlineColor: '#d1d1d1',
+            labelOutlineColorMatchStroke: false,
+            labelFontSize: _defaultLabelFontSize,
+            labelFontSizeRelative: true,
+            labelOutlineWidth: _defaultLabelOutlineWidth,
+            labelOutlineWidthRelative: true,
+            highlightColor: _defaultHighlightColor,
+          },
+        };
+
+        /**
+         * Applies a Quick Preset by merging it into `_settings`, persisting the result, and
+         * updating every DOM control in the panel to reflect the new values. Both the polygon
+         * and label layers are redrawn immediately.
+         *
+         * @param {Object} p - A fully-specified preset object containing all style keys.
+         */
+        function applyPreset(p) {
+          Object.assign(_settings, p);
           saveSettings();
+          // Polygon style
+          strokeColorInput.value = _settings.strokeColor;
+          fillColorInput.value = _settings.fillColor;
+          const sliders = styleCard.querySelectorAll('.co-slider');
+          sliders[0].value = _settings.strokeOpacity;
+          sliders[1].value = _settings.fillOpacity;
+          sliders.forEach((s) => updateSlider(s));
+          // Label color
+          labelColorInput.value = _settings.labelColorMatchStroke ? _settings.strokeColor : _settings.labelColor;
+          labelColorInput.disabled = _settings.labelColorMatchStroke;
+          labelColorSyncToggle.querySelector('input').checked = _settings.labelColorMatchStroke;
+          // Outline color
+          outlineColorInput.value = _settings.labelOutlineColorMatchStroke ? _settings.strokeColor : _settings.labelOutlineColor;
+          outlineColorInput.disabled = _settings.labelOutlineColorMatchStroke;
+          outlineColorSyncToggle.querySelector('input').checked = _settings.labelOutlineColorMatchStroke;
+          // Font size
+          fontSizeNumInput.value = _settings.labelFontSize;
+          fontSizeNumInput.disabled = _settings.labelFontSizeRelative;
+          fontSizeAutoToggle.querySelector('input').checked = _settings.labelFontSizeRelative;
+          // Outline width
+          outlineWidthNumInput.value = _settings.labelOutlineWidth;
+          outlineWidthNumInput.disabled = _settings.labelOutlineWidthRelative;
+          outlineWidthAutoToggle.querySelector('input').checked = _settings.labelOutlineWidthRelative;
+          // Redraw both layers
           wmeSDK.Map.redrawLayer({ layerName: layerid });
+          wmeSDK.Map.redrawLayer({ layerName: labelsLayerId });
+        }
+
+        presetsDiv.querySelectorAll('.co-preset-chip').forEach((chip) => {
+          chip.addEventListener('click', () => {
+            const preset = PRESETS[chip.dataset.preset];
+            if (preset) applyPreset(preset);
+          });
         });
 
-        $('#_cbCOHighlightFocusedCity').change(function () {
-          _settings.HighlightFocusedCity = this.checked;
-          saveSettings();
-          wmeSDK.Map.redrawLayer({ layerName: layerid });
-        });
+        // Database card
+        const dbCard = document.createElement('div');
+        dbCard.className = 'co-card';
+        const dbTitle = document.createElement('div');
+        dbTitle.className = 'co-card-title';
+        dbTitle.textContent = 'Database';
+        dbCard.appendChild(dbTitle);
+
+        dbCard.appendChild(
+          makeRow(
+            'Auto-update on load',
+            makeToggle(_settings.AutoUpdateKMLs, (checked) => {
+              _settings.AutoUpdateKMLs = checked;
+              saveSettings();
+            }),
+          ),
+        );
+
+        const updateBtn = document.createElement('button');
+        updateBtn.className = 'co-btn';
+        updateBtn.textContent = 'Refresh / Update Database';
+        updateBtn.addEventListener('click', updateAllMaps);
+        dbCard.appendChild(updateBtn);
+
+        const statusDiv = document.createElement('div');
+        statusDiv.id = 'WMECOupdateStatus';
+        statusDiv.className = 'co-status';
+        dbCard.appendChild(statusDiv);
+
+        tabPane.appendChild(dbCard);
       })
       .catch((error) => {
         console.error(`${scriptName}: Error registering the script tab:`, error);
       });
   }
 
+  /**
+   * Handles the `wme-map-move-end` event. Triggers a city layer refresh whenever the
+   * layer is currently visible.
+   */
   function onMapMove() {
     if (_settings.layerVisible) {
       updateCitiesLayer();
     }
   }
 
-  function layerToggled() {
-    // Toggle the visibility state
-    _settings.layerVisible = !_settings.layerVisible;
-    const visible = _settings.layerVisible;
+  /**
+   * Sets the layer visibility to `value`, syncing the map layers, the layer-switcher
+   * checkbox, and the sidebar power button color. Triggers a city refresh on show,
+   * or removes the district name label on hide. Persists the new visibility state.
+   */
+  function setLayerVisible(value) {
+    _settings.layerVisible = value;
 
-    wmeSDK.Map.setLayerVisibility({ layerName: layerid, visibility: visible });
-    wmeSDK.LayerSwitcher.setLayerCheckboxChecked({ name: 'Cities Overlay', isChecked: visible });
+    wmeSDK.Map.setLayerVisibility({ layerName: layerid, visibility: value });
+    wmeSDK.Map.setLayerVisibility({ layerName: labelsLayerId, visibility: value });
+    wmeSDK.LayerSwitcher.setLayerCheckboxChecked({ name: 'Cities Overlay', isChecked: value });
+    $('span#cities-overlay-power-btn').css({ color: value ? '#00bd00' : '#ccc' });
 
-    if (visible) {
-      $('#citiesPower').css('color', 'rgb(0,180,0)');
-      // Add a custom event listener for visibility changes
-      document.getElementById('citiesPower').addEventListener('visibilityChange', updateCitiesLayer);
-      // Dispatch or trigger the custom event
-      const visibilityChangeEvent = new Event('visibilityChange');
-      document.getElementById('citiesPower').dispatchEvent(visibilityChangeEvent);
+    if (value) {
+      updateCitiesLayer();
     } else {
-      $('#citiesPower').css('color', 'rgb(255, 0, 0)'); // Dark mode color
-      $('.wmecitiesoverlay-region').remove(); // Remove existing district name displays
-      // Remove the custom event listener when not visible
-      document.getElementById('citiesPower').removeEventListener('visibilityChange', updateCitiesLayer);
+      $('.wmecitiesoverlay-region').remove();
     }
     saveSettings();
+  }
+
+  /**
+   * Handles the `wme-layer-checkbox-toggled` event fired by the WME layer switcher.
+   * Delegates to setLayerVisible using the checkbox's authoritative checked state.
+   */
+  function layerToggled(args) {
+    setLayerVisible(args.checked);
   }
 
   /**
@@ -1152,8 +1723,6 @@
 
       // End loading indicator
       console.timeEnd(`${scriptName}: Loaded City Polygons for ${topState.name} in`);
-    } else {
-      wmeSDK.Map.redrawLayer({ layerName: layerid });
     }
   }
 
@@ -1185,33 +1754,22 @@
    */
   function updatePolygons() {
     // Retrieve GeoJSON features from the KML string; conversion handled inside GetFeaturesFromKMLString
-    _layer = GetFeaturesFromKMLString(_kml);
-    // Remove all existing features from the specified layer
-    try {
-      wmeSDK.Map.removeAllFeaturesFromLayer({ layerName: layerid });
-      if (debug) console.log(`${scriptName}: All features removed from layer: ${layerid}`);
-    } catch (error) {
-      console.error(`${scriptName}: Error removing features from layer: ${layerid}`, error);
-    }
+    const rawFeatures = GetFeaturesFromKMLString(_kml);
 
-    // Map features array with unique index-based IDs
-    const featuresToLoad = _layer.map((f, index) => ({
+    // Build polygon features with stable IDs, type marker, and pre-computed bbox
+    _layer = rawFeatures.map((f, index) => ({
       type: f.type,
-      id: `${layerid}_${index}`, // Use feature index for uniqueness
+      id: `${layerid}_${index}`,
       geometry: f.geometry,
-      properties: f.properties,
+      properties: { ...f.properties, type: 'city', _bbox: turf.bbox(f) },
     }));
 
-    wmeSDK.Map.dangerouslyAddFeaturesToLayerWithoutValidation({
-          features: featuresToLoad,
-          layerName: layerid,
-        });
-
-    _layer = featuresToLoad; // populates the global _layer
     if (debug) console.log(`${scriptName}: Current State is ${currState}`);
-
-    // Log completion
-    console.log(`${scriptName}: ${featuresToLoad.length} Towns added`);
+    console.log(`${scriptName}: ${_layer.length} Towns loaded`);
     if (debug) console.log(`${scriptName}: Layers Loaded are:`, _layer);
+
+    // Add all polygon features once; labels are handled separately
+    addPolygonsToLayer();
+    refreshLabels();
   }
 })();


### PR DESCRIPTION
## New Features

### Power Button in Sidebar Tab Label

Moved the power button to the Tab Label.

- A Font Awesome `fa-power-off` icon is injected into the "Cities" sidebar tab label alongside the
  tab text.
- The button is **green (`#00bd00`)** when the overlay is on and **grey (`#ccc`)** when off.
- Clicking the icon toggles the overlay on/off without activating or switching the sidebar tab
  (`return false` suppresses the parent click).
- The button colour is initialised from the persisted `layerVisible` setting on load, so the visual
  state is always correct after a page refresh.
- The button stays in sync when the overlay is toggled from the WME Layers menu checkbox and
  vice-versa — both paths go through a single `setLayerVisible(value)` function.

### Turf.js Integration

- Added `@turf/turf@7` as a `@require` dependency.
- All geometry work now delegates to the turf library rather than hand-rolled algorithms.

### Full Polygon & Label Style Customisation

Users can now independently control every visual aspect of the overlay directly from the sidebar panel:

| Setting                          | Details                                             |
| -------------------------------- | --------------------------------------------------- |
| **Stroke Color**                 | Custom colour picker                                |
| **Fill Color**                   | Custom colour picker                                |
| **Stroke Opacity**               | Slider + quick-select presets (5 % – 75 %)          |
| **Fill Opacity**                 | Slider + quick-select presets (5 % – 75 %)          |
| **Label Color**                  | Colour picker with optional "Sync to Stroke" toggle |
| **Label Outline Color**          | Colour picker with optional "Sync to Stroke" toggle |
| **Label Font Size**              | Manual number input **or** zoom-relative Auto mode  |
| **Label Outline Width**          | Manual number input **or** zoom-relative Auto mode  |
| **Highlight Focused City Color** | Configurable per-preset; no longer hardcoded        |

### Zoom-Relative Label Sizing

- Labels are hidden below zoom level 12 (the first level where they are useful).
- In Auto mode, font size scales as `20 + (zoom − 12) × 2 px`, growing 2 px per zoom step for
  natural readability at any zoom level.

### Quick Presets

Replaced the "Reset to defaults" button with a **Quick Presets** chip bar. Each preset fully
specifies every style setting for predictable, consistent results regardless of prior state.

| Preset            | Stroke / Fill                             | Highlight            |
| ----------------- | ----------------------------------------- | -------------------- |
| **Default**       | `#E6E6E6` / 60 % stroke, 20 % fill        | `#f7ad25` amber      |
| **High Contrast** | `#ffff00` yellow / 90 % stroke, 40 % fill | `#FF4500` orange-red |
| **Minimal**       | `#AAAAAA` / 30 % stroke, 10 % fill        | `#f7ad25` amber      |
| **Colorblind**    | `#DE8F05` amber / default opacities       | `#CC78BC` pink       |
| **Night Mode**    | `#4B0082` indigo / 70 % stroke, 15 % fill | `#f7ad25` amber      |

> High Contrast and Colorblind presets use distinct highlight colours to ensure the focused-city
> highlight remains clearly visible against their yellow/amber stroke colours.

---

## Bug Fixes

### Layer Toggle State Synchronisation

The previous `layerToggled()` handler blindly flipped `_settings.layerVisible` (`!value`) on every
call. If the WME layer-switcher event fired out of order or multiple times, the state could drift out
of sync with the actual checkbox.

The handler now receives the `args` object from the `wme-layer-checkbox-toggled` event and passes
`args.checked` — the authoritative boolean from the checkbox itself — directly to
`setLayerVisible(value)`. State is always deterministic regardless of event ordering.

### Point-in-Polygon Hole Detection

The previous `isPointInPolygon` implementation only tested against the outer ring
(`geometry.coordinates[0]`), silently returning `true` for points inside polygon holes.
`turf.booleanPointInPolygon` correctly handles holes, so city detection is now accurate for
any polygon shape.

---

## Geometry Engine Improvements

### Replaced with Turf Equivalents (dead code removed)

| Removed Function                                       | Lines Saved | Replaced By                        |
| ------------------------------------------------------ | ----------- | ---------------------------------- |
| `isPointInPolygon()` — manual ray-cast algorithm       | ~12         | `turf.booleanPointInPolygon()`     |
| `geoBbox()` — manual min/max coordinate loop           | ~15         | `turf.bbox()`                      |
| `geomEach()` — custom multi-geometry iterator          | ~25         | _(consumed by `turf.flattenEach`)_ |
| `flattenGeoJSON()` body — manual Multi\* decomposition | ~70         | `turf.flattenEach()`               |

**Net reduction: ~120 lines of geometry code removed.**

---

## Code Quality

### New `setLayerVisible(value)` Function

Extracted from the old `layerToggled()` into a dedicated function that is the single source of truth
for all visibility changes. It handles:

- Updating `_settings.layerVisible`
- Syncing both map layers (polygons + labels) via `wmeSDK.Map.setLayerVisibility`
- Syncing the "Cities Overlay" layer-switcher checkbox
- Updating the sidebar power button colour
- Triggering a city refresh on show, or removing the district name label on hide
- Persisting settings to localStorage

### Dead Code Removed

- Deleted `isChecked()` — jQuery helper leftover from an older WME coding style, never called.
- Deleted `setChecked()` — same origin, never called.
- Removed unused `geometry` local variable in `findCurrCity`.

### Default Constants Refactored

Replaced the single `_color` constant and scattered literals with named per-property defaults:
`_defaultStrokeColor`, `_defaultFillColor`, `_defaultStrokeOpacity`, `_defaultFillOpacity`,
`_defaultLabelColor`, `_defaultLabelOutlineColor`, `_defaultLabelFontSize`,
`_defaultLabelOutlineWidth`, `_defaultHighlightColor`.

### Settings Expanded & Hardened

- `loadSettings` and `saveSettings` now persist all new style and label settings.
- Default-merging loop uses `Object.prototype.hasOwnProperty.call` instead of the deprecated
  `.hasOwnProperty()` direct call.
- `var` → `const`/`let` throughout both functions.

### Screen Polygon Caching

Introduced `_cachedExtent`, `_cachedScreenPolygon`, and `_cachedScreenArea` module-level variables.
`ensurePolygonCaches()` rebuilds the viewport polygon and area only when the map extent actually
changes, avoiding redundant `turf.polygon` + `turf.area` calls on every label refresh.

### JSDoc Coverage

Added JSDoc to every previously undocumented function in the script:

`bootstrap` · `isWmeReady` · `isWazeWrapReady` · `isGeoKMLerReady` · `loadSettings` ·
`saveSettings` · `stripElevation` · `flattenGeoJSON` · `GetFeaturesFromKMLString` ·
`updateDistrictNameDisplay` · `addPolygonsToLayer` · `refreshLabels` · `getLabelPoints` ·
`ensurePolygonCaches` · `getScreenPolygon` · `getScreenArea` · `fetch` · `init` · `initTab` ·
`updateSlider` · `makeToggle` · `makeRow` · `makeSliderRow` · `makeColorSyncRow` ·
`makeNumberAutoRow` · `applyPreset` · `onMapMove` · `setLayerVisible` · `layerToggled`
